### PR TITLE
Use provider in store

### DIFF
--- a/client/components/App.js
+++ b/client/components/App.js
@@ -247,7 +247,7 @@ class App extends Common {
         <main>
           <Switch>
             <Route exact path="/">
-              <LandingPage />
+              <LandingPage Store={Store} setStore={this.setStore} />
             </Route>
             <Route exact path="*">
               <Error404 Store={Store} setStore={this.setStore} />

--- a/client/components/LandingPage.js
+++ b/client/components/LandingPage.js
@@ -3,13 +3,14 @@ import NFTs from "./NFTs";
 import Leaderboard from "./Leaderboard";
 import MyProgressbar from "./MyProgressBar";
 import Button from "./BuySynbtn";
+import Base from "./Base";
 
 // eslint-disable-next-line no-undef
 const { Container } = ReactBootstrap;
 const progress_now = 25;
 
 // eslint-disable-next-line no-undef
-export default class LandingPage extends React.Component {
+export default class LandingPage extends Base {
   componentDidMount() {
     // window.location = 'https://syn.city'
   }
@@ -59,30 +60,28 @@ export default class LandingPage extends React.Component {
 
               <NFTs />
               <div className="App">
-                <p>
-                  <div className="progressBarComplete">
-                    <h4 className="progressBarAddress">
-                      You:address placeholder
-                    </h4>
-                    <div className="progressBar">
-                      <div className="progressBar2">
-                        <MyProgressbar
-                          bgcolor="yellow"
-                          progress={progress_now}
-                          height={55}
-                        />
-                      </div>
-                      <div className="buySYNbtn2">
-                        <Button classname="buySYNbtn" text="BUY $SYN" />
-                      </div>
+                <div className="progressBarComplete">
+                  <div className="progressBarAddress">
+                    You:address placeholder
+                  </div>
+                  <div className="progressBar">
+                    <div className="progressBar2">
+                      <MyProgressbar
+                        bgcolor="yellow"
+                        progress={progress_now}
+                        height={55}
+                      />
+                    </div>
+                    <div className="buySYNbtn2">
+                      <Button classname="buySYNbtn" text="BUY $SYN" />
                     </div>
                   </div>
-                </p>
+                </div>
               </div>
 
               <br style={{ clear: "both" }} />
 
-              <Leaderboard />
+              <Leaderboard Store={this.Store} setStore={this.setStore} />
               <div className="foot">
                 <img src={"/images/yellowLogo.png"} alt={"footer"} />
               </div>

--- a/client/components/NFTs.js
+++ b/client/components/NFTs.js
@@ -9,7 +9,7 @@ export default class NFTs extends React.Component {
               <img src={"/images/NFTleft.png"} alt={"logo"} />
               <div className={"topRow centered"}>
                 <span className={"nftTextGold"}>Top 50 </span>
-                <spam className={"nftText"}>reward:</spam>
+                <span className={"nftText"}>reward:</span>
               </div>
               <b className={"boldNFT centered"}>ORIGINAL SYNNER CEO</b>
             </div>

--- a/monitor/blockchainQueryService.js
+++ b/monitor/blockchainQueryService.js
@@ -7,50 +7,44 @@ const START_BLOCK = 7700000;
 const END_BLOCK = 7700100;
 
 const queryService = {
-    async getEvents() {
-        const provider = new Ethers.providers.InfuraProvider("mainnet", {
-            projectId: "a5d8ae5cf48e49269d71a5cf25289c0d",
-        });
-        const contract = new Ethers.Contract(
-            CONTRACT_ADDRESS,
-            ERC20abi,
-            provider
-        );
-        const oldevents = await contract.queryFilter(
-            "Transfer",
-            START_BLOCK,
-            END_BLOCK
-        );
-        for (let i = 0; i < oldevents.length; i++) {
-            console.log(oldevents[i]);
-            console.log(oldevents[i].transactionHash);
-            console.log(oldevents[i].args.from);
-            console.log(Ethers.utils.formatEther(oldevents[i].args.value));
-            const etherValue = Ethers.utils.formatEther(
-                oldevents[i].args.value
-            );
-            const hash = oldevents[i].transactionHash;
-            const wallet = oldevents[i].args.from;
-            const newinvestment = await dbManager.newInvestment(
-                etherValue,
-                wallet,
-                hash
-            );
-            console.log(newinvestment);
-        }
+  async getEvents() {
+    const provider = new Ethers.providers.InfuraProvider("mainnet", {
+      projectId: "a5d8ae5cf48e49269d71a5cf25289c0d",
+    });
+    const contract = new Ethers.Contract(CONTRACT_ADDRESS, ERC20abi, provider);
+    const oldevents = await contract.queryFilter(
+      "Transfer",
+      START_BLOCK,
+      END_BLOCK
+    );
+    for (let i = 0; i < oldevents.length; i++) {
+      console.log(oldevents[i]);
+      console.log(oldevents[i].transactionHash);
+      console.log(oldevents[i].args.from);
+      console.log(Ethers.utils.formatEther(oldevents[i].args.value));
+      const etherValue = Ethers.utils.formatEther(oldevents[i].args.value);
+      const hash = oldevents[i].transactionHash;
+      const wallet = oldevents[i].args.from;
+      const newinvestment = await dbManager.newInvestment(
+        etherValue,
+        wallet,
+        hash
+      );
+      console.log(newinvestment);
+    }
 
-        contract.on("Transfer", async (from, to, value, event) => {
-            console.log(event);
-            const etherValue = Ethers.utils.formatEther(event.args.value);
-            const hash = event.transactionHash;
-            const wallet = event.args.from;
-            const newinvestment = await dbManager.newInvestment(
-                etherValue,
-                wallet,
-                hash
-            );
-            console.log(newinvestment);
-        });
-    },
+    contract.on("Transfer", async (from, to, value, event) => {
+      console.log(event);
+      const etherValue = Ethers.utils.formatEther(event.args.value);
+      const hash = event.transactionHash;
+      const wallet = event.args.from;
+      const newinvestment = await dbManager.newInvestment(
+        etherValue,
+        wallet,
+        hash
+      );
+      console.log(newinvestment);
+    });
+  },
 };
 module.exports = queryService;


### PR DESCRIPTION
In relation to issue https://github.com/superpowerlabs/copper-leaderboard/issues/13

In `Leaderboard.getEvents`, instead of resetting the connection to Metamask, uses existing objects stored in the Store.

To avoid accessing the store too early, when the signer is not existing, if wait for the connection, calling `this.waitForWeb3` (method defined in `Base.js`).

It also cleans a couple of errors in the hierarchy of the html tags.