### PR TITLE
Refactoring security 2

### DIFF
--- a/client/components/NFTs.js
+++ b/client/components/NFTs.js
@@ -3,9 +3,9 @@ import React from "react";
 import { Row, Col } from "react-bootstrap";
 import Base from "./Base";
 
-const top200 = "https://data.mob.land/assets/top200_2.gif";
-const top100 = "https://data.mob.land/assets/top100_2.gif";
-const top50 = "https://data.mob.land/assets/top50_2.gif";
+const top200 = "https://data.mob.land/assets/top200_2.mp4";
+const top100 = "https://data.mob.land/assets/top100_2.mp4";
+const top50 = "https://data.mob.land/assets/top50_2.mp4";
 
 // eslint-disable-next-line no-undef
 export default class NFTs extends Base {
@@ -13,9 +13,16 @@ export default class NFTs extends Base {
     return (
       <Row className={"nftLogos bold"}>
         <Col xs={12} lg={4}>
-          <div className={"videoContainer"}>
-            <img src={top200} />
-          </div>
+          <video
+            id="top200"
+            className="videoContainer"
+            autoPlay
+            muted
+            preload="preload"
+            loop
+          >
+            <source src={top200} type="video/mp4" />
+          </video>
           <div className={"topRow centered"}>
             <span className={"nftTextBronze"}>Top 101-200 </span>
             <span className={"nftText"}>reward:</span>
@@ -24,9 +31,16 @@ export default class NFTs extends Base {
         </Col>
 
         <Col xs={12} lg={4}>
-          <div className={"videoContainer"}>
-            <img src={top100} />
-          </div>
+          <video
+            id="top200"
+            className="videoContainer"
+            autoPlay
+            muted
+            preload="preload"
+            loop
+          >
+            <source src={top100} type="video/mp4" />
+          </video>
           <div className={"topRow centered"}>
             <span className={"nftTextSilver"}>Top 51-100 </span>
             <span className={"nftText"}>reward:</span>
@@ -34,9 +48,16 @@ export default class NFTs extends Base {
           <b className={"boldNFT centered"}>ORIGINAL SYNNER SILVER</b>
         </Col>
         <Col xs={12} lg={4}>
-          <div className={"videoContainer"}>
-            <img src={top50} />
-          </div>
+          <video
+            id="top200"
+            className="videoContainer"
+            autoPlay
+            muted
+            preload="preload"
+            loop
+          >
+            <source src={top50} type="video/mp4" />
+          </video>
           <div className={"topRow centered"}>
             <span className={"nftTextGold"}>Top 50 </span>
             <span className={"nftText"}>reward:</span>

--- a/server/app.js
+++ b/server/app.js
@@ -51,7 +51,10 @@ app.use("/healthcheck", function (req, res) {
   res.send("ok");
 });
 
-applyNonce(app, {});
+applyNonce(app, {
+  index_file: "../../public/index.html",
+  static_assets: ["images", "styles", "bundle"],
+});
 
 app.use(express.static(path.resolve(__dirname, "../public")));
 

--- a/server/app.js
+++ b/server/app.js
@@ -27,7 +27,7 @@ const security_config = {
   font: ["fonts.gstatic.com/", "use.fontawesome.com/"],
   img: ["data:", "www.w3.org/"],
   index_file: "../../public/index.html",
-  static_assets: ["images", "styles", "bundle"],
+  static_assets: ["favicon.png", "favicon.ico", "images", "styles", "bundle"],
 };
 
 applySecurity(app, security_config);

--- a/server/app.js
+++ b/server/app.js
@@ -12,14 +12,11 @@ const applyNonce = require("./applyNonce");
 process.on("uncaughtException", function (error) {
   Logger.error(error.message);
   Logger.error(error.stack);
-
-  // if(!error.isOperational)
-  //   process.exit(1)
 });
 
 const app = express();
 
-applySecurity(app, {
+const security_config = {
   connect: ["ka-f.fontawesome.com"],
   style: [
     "'unsafe-hashes'",
@@ -29,7 +26,11 @@ applySecurity(app, {
   ],
   font: ["fonts.gstatic.com/", "use.fontawesome.com/"],
   img: ["data:", "www.w3.org/"],
-});
+  index_file: "../../public/index.html",
+  static_assets: ["images", "styles", "bundle"],
+};
+
+applySecurity(app, security_config);
 
 app.use(cors());
 app.use(cookieParser());
@@ -51,11 +52,7 @@ app.use("/healthcheck", function (req, res) {
   res.send("ok");
 });
 
-applyNonce(app, {
-  index_file: "../../public/index.html",
-  static_assets: ["images", "styles", "bundle"],
-});
-
+applyNonce(app, security_config);
 app.use(express.static(path.resolve(__dirname, "../public")));
 
 // catch 404 and forward to error handler

--- a/server/app.js
+++ b/server/app.js
@@ -37,11 +37,6 @@ app.use(cookieParser());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ limit: "10mb", extended: false }));
 
-app.use((req, res, next) => {
-  res.locals.isFirefox = /Firefox/.test(req.get("user-agent"));
-  next();
-});
-
 app.use("/api/v1", apiV1);
 
 app.use("/index.html", function (req, res) {

--- a/server/app.js
+++ b/server/app.js
@@ -38,7 +38,6 @@ function getIndex(res) {
 const app = express();
 
 applySecurity(app, {
-  script: ["'unsafe-eval'"],
   connect: ["ka-f.fontawesome.com"],
   style: [
     "'unsafe-hashes'",
@@ -47,7 +46,7 @@ applySecurity(app, {
     "use.fontawesome.com/releases/v6.0.0-beta1/",
   ],
   font: ["fonts.gstatic.com/", "use.fontawesome.com/"],
-  img: ["www.w3.org/"],
+  img: ["data:", "www.w3.org/"],
 });
 
 app.use(cors());

--- a/server/applyNonce/index.js
+++ b/server/applyNonce/index.js
@@ -1,28 +1,34 @@
 const fs = require("fs-extra");
 const path = require("path");
 
-function getIndex(res, html) {
+function getIndex(html, index_file) {
   if (!html) {
-    html = fs.readFileSync(
-      path.resolve(__dirname, "../../public/index.html"),
-      "utf-8"
-    );
+    html = fs.readFileSync(path.resolve(__dirname, index_file), "utf-8");
   }
+  return html;
+}
+
+function insertNonce(res, html, index_file) {
+  html = getIndex(html, index_file);
   if (res.locals.isFirefox === true) {
     return html;
   } else {
     return html
       .replace(/<script/g, `<script nonce="${res.locals.nonce}"`)
-      .replace(/<link/g, `<link nonce="${res.locals.nonce}"`);
+      .replace(/<link/g, `<link nonce="${res.locals.nonce}"`)
+      .replace(/<style/g, `<style nonce="${res.locals.nonce}"`);
   }
 }
 
 module.exports = (app, extraConfig) => {
   let html;
+  // TODO check path to index, set default?
+  let index_file = extraConfig.index_file;
+  let static_assets = extraConfig.static_assets || [];
 
   app.use("*", function (req, res, next) {
     if (req.params["0"] === "/") {
-      res.send(getIndex(res, html));
+      res.send(insertNonce(res, html, index_file));
     } else {
       next();
     }
@@ -30,17 +36,10 @@ module.exports = (app, extraConfig) => {
 
   app.use("/:anything", function (req, res, next) {
     let v = req.params.anything;
-    switch (v) {
-      case "favicon.png":
-      case "favicon.ico":
-      case "styles":
-      case "all":
-      case "images":
-      case "bundle":
-        next();
-        break;
-      default:
-        res.send(getIndex(res, html));
+    if (static_assets.includes(v)) {
+      next();
+    } else {
+      res.send(insertNonce(res, html, index_file));
     }
   });
 };

--- a/server/applyNonce/index.js
+++ b/server/applyNonce/index.js
@@ -8,9 +8,9 @@ function getIndex(html, index_file) {
   return html;
 }
 
-function insertNonce(res, html, index_file) {
+function insertNonce(res, req, html, index_file) {
   html = getIndex(html, index_file);
-  if (res.locals.isFirefox === true) {
+  if (/Firefox/.test(req.get("user-agent"))) {
     return html;
   } else {
     return html
@@ -28,7 +28,7 @@ module.exports = (app, extraConfig) => {
 
   app.use("*", function (req, res, next) {
     if (req.params["0"] === "/") {
-      res.send(insertNonce(res, html, index_file));
+      res.send(insertNonce(res, req, html, index_file));
     } else {
       next();
     }
@@ -39,7 +39,7 @@ module.exports = (app, extraConfig) => {
     if (static_assets.includes(v)) {
       next();
     } else {
-      res.send(insertNonce(res, html, index_file));
+      res.send(insertNonce(res, req, html, index_file));
     }
   });
 };

--- a/server/applyNonce/index.js
+++ b/server/applyNonce/index.js
@@ -1,0 +1,46 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+function getIndex(res, html) {
+  if (!html) {
+    html = fs.readFileSync(
+      path.resolve(__dirname, "../../public/index.html"),
+      "utf-8"
+    );
+  }
+  if (res.locals.isFirefox === true) {
+    return html;
+  } else {
+    return html
+      .replace(/<script/g, `<script nonce="${res.locals.nonce}"`)
+      .replace(/<link/g, `<link nonce="${res.locals.nonce}"`);
+  }
+}
+
+module.exports = (app, extraConfig) => {
+  let html;
+
+  app.use("*", function (req, res, next) {
+    if (req.params["0"] === "/") {
+      res.send(getIndex(res, html));
+    } else {
+      next();
+    }
+  });
+
+  app.use("/:anything", function (req, res, next) {
+    let v = req.params.anything;
+    switch (v) {
+      case "favicon.png":
+      case "favicon.ico":
+      case "styles":
+      case "all":
+      case "images":
+      case "bundle":
+        next();
+        break;
+      default:
+        res.send(getIndex(res, html));
+    }
+  });
+};

--- a/server/applySecurity/index.js
+++ b/server/applySecurity/index.js
@@ -20,7 +20,6 @@ module.exports = (app, extraConfig) => {
 
   app.use((req, res, next) => {
     if (res.locals.isHome) {
-      console.info("helmet on for index");
       helmet()(req, res, next);
     } else {
       next();
@@ -33,7 +32,6 @@ module.exports = (app, extraConfig) => {
 
   app.use((req, res, next) => {
     if (res.locals.isHome) {
-      console.info("CSP on for index");
       CSP(extraConfig)(req, res, next);
     } else {
       next();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,13 +47,5 @@ module.exports = (env, argv) => {
     config.devtool = "inline-source-map";
   }
 
-  if (mode === "production" || argv.mode === "production") {
-    config.plugins.push(
-      new ESLintPlugin({
-        files: "src/**/*.js",
-      })
-    );
-  }
-
   return config;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,11 +43,11 @@ const config = {
 };
 
 module.exports = (env, argv) => {
-  if (argv.mode === "development") {
+  if (mode === "development" || argv.mode === "development") {
     config.devtool = "inline-source-map";
   }
 
-  if (argv.mode === "production") {
+  if (mode === "production" || argv.mode === "production") {
     config.plugins.push(
       new ESLintPlugin({
         files: "src/**/*.js",


### PR DESCRIPTION
### 1/ Remove "unsafe-eval" directive
I removed the "unsafe-eval" directive b/c it's unsafe:
- the CSP errors that this addressed were generated only in development (production works wo this directive) b/c of a bug in the webconfig file
- fixed webconfig file, that wasn't taking the `config.devtool = "inline-source-map";` into account when running `ENV=development pnpm build; pnpm start`, b/c webconfig was expecting to see "development" as an arg only not an ENV var.
### 2/ Move nonce for index to its own middleware